### PR TITLE
Mengni/issue 7 drag terms back to container

### DIFF
--- a/back.html
+++ b/back.html
@@ -1,2 +1,100 @@
-<script>window.ankiShowSolution = true;</script>
+<script>
+// anki-persistence library - same as front side
+if (typeof(window.Persistence) === 'undefined') {
+    var _persistenceKey = 'github.com/SimonLammer/anki-persistence/';
+    var _defaultKey = '_default';
+    window.Persistence_sessionStorage = function() {
+        var isAvailable = false;
+        try {
+            if (typeof(window.sessionStorage) === 'object') {
+                isAvailable = true;
+                this.clear = function() {
+                    for (var i = 0; i < sessionStorage.length; i++) {
+                        var k = sessionStorage.key(i);
+                        if (k.indexOf(_persistenceKey) == 0) {
+                            sessionStorage.removeItem(k);
+                            i--;
+                        }
+                    }
+                };
+                this.setItem = function(key, value) {
+                    if (value == undefined) {
+                        value = key;
+                        key = _defaultKey;
+                    }
+                    sessionStorage.setItem(_persistenceKey + key, JSON.stringify(value));
+                };
+                this.getItem = function(key) {
+                    if (key == undefined) {
+                        key = _defaultKey;
+                    }
+                    return JSON.parse(sessionStorage.getItem(_persistenceKey + key));
+                };
+                this.removeItem = function(key) {
+                    if (key == undefined) {
+                        key = _defaultKey;
+                    }
+                    sessionStorage.removeItem(_persistenceKey + key);
+                };
+            }
+        } catch(err) {}
+        this.isAvailable = function() {
+            return isAvailable;
+        };
+    };
+    window.Persistence_windowKey = function(key) {
+        var isAvailable = false;
+        try {
+            if (typeof(window[key]) === 'object') {
+                isAvailable = true;
+                this.clear = function() {
+                    window[key] = {};
+                };
+                this.setItem = function(key, value) {
+                    if (value == undefined) {
+                        value = key;
+                        key = _defaultKey;
+                    }
+                    window[key][_persistenceKey + key] = value;
+                };
+                this.getItem = function(key) {
+                    if (key == undefined) {
+                        key = _defaultKey;
+                    }
+                    return window[key][_persistenceKey + key];
+                };
+                this.removeItem = function(key) {
+                    if (key == undefined) {
+                        key = _defaultKey;
+                    }
+                    delete window[key][_persistenceKey + key];
+                };
+            }
+        } catch(err) {}
+        this.isAvailable = function() {
+            return isAvailable;
+        };
+    };
+    window.Persistence = new Persistence_sessionStorage();
+    if (!window.Persistence.isAvailable()) {
+        window.Persistence = new Persistence_windowKey(window.location.href);
+        if (!window.Persistence.isAvailable()) {
+            window.Persistence = new Persistence_windowKey('anki-persistence');
+        }
+    }
+}
+
+// Set solution flag for back side
+if (window.Persistence && window.Persistence.isAvailable()) {
+    window.Persistence.setItem('showSolution', true);
+}
+</script>
 {{FrontSide}}
+<script>
+// Clear persistence after back side is shown to prevent bleeding into next card
+setTimeout(function() {
+    if (window.Persistence && window.Persistence.isAvailable()) {
+        window.Persistence.clear();
+    }
+}, 100);
+</script>

--- a/front.html
+++ b/front.html
@@ -28,7 +28,101 @@
 </div>
 
 <script>
+// anki-persistence library
+if (typeof(window.Persistence) === 'undefined') {
+    var _persistenceKey = 'github.com/SimonLammer/anki-persistence/';
+    var _defaultKey = '_default';
+    window.Persistence_sessionStorage = function() {
+        var isAvailable = false;
+        try {
+            if (typeof(window.sessionStorage) === 'object') {
+                isAvailable = true;
+                this.clear = function() {
+                    for (var i = 0; i < sessionStorage.length; i++) {
+                        var k = sessionStorage.key(i);
+                        if (k.indexOf(_persistenceKey) == 0) {
+                            sessionStorage.removeItem(k);
+                            i--;
+                        }
+                    }
+                };
+                this.setItem = function(key, value) {
+                    if (value == undefined) {
+                        value = key;
+                        key = _defaultKey;
+                    }
+                    sessionStorage.setItem(_persistenceKey + key, JSON.stringify(value));
+                };
+                this.getItem = function(key) {
+                    if (key == undefined) {
+                        key = _defaultKey;
+                    }
+                    return JSON.parse(sessionStorage.getItem(_persistenceKey + key));
+                };
+                this.removeItem = function(key) {
+                    if (key == undefined) {
+                        key = _defaultKey;
+                    }
+                    sessionStorage.removeItem(_persistenceKey + key);
+                };
+            }
+        } catch(err) {}
+        this.isAvailable = function() {
+            return isAvailable;
+        };
+    };
+    window.Persistence_windowKey = function(key) {
+        var isAvailable = false;
+        try {
+            if (typeof(window[key]) === 'object') {
+                isAvailable = true;
+                this.clear = function() {
+                    window[key] = {};
+                };
+                this.setItem = function(key, value) {
+                    if (value == undefined) {
+                        value = key;
+                        key = _defaultKey;
+                    }
+                    window[key][_persistenceKey + key] = value;
+                };
+                this.getItem = function(key) {
+                    if (key == undefined) {
+                        key = _defaultKey;
+                    }
+                    return window[key][_persistenceKey + key];
+                };
+                this.removeItem = function(key) {
+                    if (key == undefined) {
+                        key = _defaultKey;
+                    }
+                    delete window[key][_persistenceKey + key];
+                };
+            }
+        } catch(err) {}
+        this.isAvailable = function() {
+            return isAvailable;
+        };
+    };
+    window.Persistence = new Persistence_sessionStorage();
+    if (!window.Persistence.isAvailable()) {
+        window.Persistence = new Persistence_windowKey(window.location.href);
+        if (!window.Persistence.isAvailable()) {
+            window.Persistence = new Persistence_windowKey('anki-persistence');
+        }
+    }
+}
+
     function run() {
+        // Always clear state at the beginning of front side to prevent persistence issues
+        if (window.Persistence && window.Persistence.isAvailable()) {
+            // Only clear if this is truly a fresh front side load (not back side)
+            const isBackSide = window.Persistence.getItem('showSolution');
+            if (!isBackSide) {
+                window.Persistence.clear();
+            }
+        }
+        
         const layout = document.getElementById("layout-field").innerText.trim().toUpperCase();
 
         const headers = [
@@ -66,30 +160,19 @@
         function initializeGame(layoutParam, validTermsParam, allTermsParam, termsContainerParam) {
             clearTable();
             
+            // Check if we should show solution (back side)
+            const isBackSide = window.Persistence && window.Persistence.isAvailable() && window.Persistence.getItem('showSolution');
             
-            // Check if we should show solution (only exists on back side)
-            if (window.ankiShowSolution) {
+            if (isBackSide) {
                 // Solution mode - display correct answers
-                validTermsParam.forEach((categoryTerms, index) => {
-                    const dropzoneId = layoutParam === 'V' ? `col${index + 1}-vert` : `col${index + 1}`;
-                    const dropzone = document.getElementById(dropzoneId);
-                    
-                    if (dropzone) {
-                        categoryTerms.forEach(termString => {
-                            const terms = termString.split('|').map(t => t.trim());
-                            terms.forEach(term => {
-                                if (term) {
-                                    dropzone.innerHTML += `<div class="term correct">${term}<div class="question-plus-one"></div></div>`;
-                                }
-                            });
-                        });
-                    }
-                });
+                showSolution(layoutParam, validTermsParam);
                 
                 // Hide interactive elements
                 if (termsContainerParam) termsContainerParam.style.display = 'none';
                 const checkButton = document.getElementById("checkButton");
                 if (checkButton) checkButton.style.display = 'none';
+                const resetButton = document.getElementById("resetButton");
+                if (resetButton) resetButton.style.display = 'none';
                 return;
             }
             
@@ -110,6 +193,24 @@
             });
 
             document.getElementById("resetButton").style.display = 'none';
+        }
+        
+        function showSolution(layoutParam, validTermsParam) {
+            validTermsParam.forEach((categoryTerms, index) => {
+                const dropzoneId = layoutParam === 'V' ? `col${index + 1}-vert` : `col${index + 1}`;
+                const dropzone = document.getElementById(dropzoneId);
+                
+                if (dropzone) {
+                    categoryTerms.forEach(termString => {
+                        const terms = termString.split('|').map(t => t.trim());
+                        terms.forEach(term => {
+                            if (term) {
+                                dropzone.innerHTML += `<div class="term correct">${term}<div class="question-plus-one"></div></div>`;
+                            }
+                        });
+                    });
+                }
+            });
         }
 
         function clearTable() {

--- a/front.html
+++ b/front.html
@@ -19,7 +19,7 @@
 <div class="game-container">
     <h1>{{Title}}</h1>
 
-    <!-- Tabelas serão criadas dinamicamente via JavaScript -->
+    <!-- Tables will be created dynamically via JavaScript -->
     <div id="dynamic-table"></div>
 
     <div id="terms-container"></div>
@@ -51,13 +51,13 @@
             document.getElementById("terms7-field").innerText.split("|")
         ];
 
-        // Filtrar cabeçalhos e termos que estão em branco
+        // Filter headers and terms that are blank
         const validHeaders = headers.filter((header, index) => header.trim() !== "" && terms[index].length > 0);
         const validTerms = terms.filter((termList, index) => headers[index].trim() !== "" && termList.length > 0);
 
-        let allTerms = validTerms.flat(); // Todos os termos para embaralhar
+        let allTerms = validTerms.flat(); // All terms to shuffle
 
-        // Criar dinamicamente a tabela com base no layout e cabeçalhos válidos
+        // Create table dynamically based on layout and valid headers
         const dynamicTable = document.getElementById("dynamic-table");
         dynamicTable.innerHTML = generateTable(layout, validHeaders);
 
@@ -66,8 +66,9 @@
         function initializeGame(layoutParam, validTermsParam, allTermsParam, termsContainerParam) {
             clearTable();
             
+            
             // Check if we should show solution (only exists on back side)
-            if (window.ankiShowSolution === true) {
+            if (window.ankiShowSolution) {
                 // Solution mode - display correct answers
                 validTermsParam.forEach((categoryTerms, index) => {
                     const dropzoneId = layoutParam === 'V' ? `col${index + 1}-vert` : `col${index + 1}`;
@@ -114,8 +115,8 @@
         function clearTable() {
             const dropzones = document.querySelectorAll('.dropzone');
             dropzones.forEach(zone => {
-                zone.innerHTML = ''; // Limpa todos os termos dentro das zonas de drop
-                zone.classList.remove('correct', 'incorrect'); // Remove as classes de estilo
+                zone.innerHTML = ''; // Clear all terms inside the drop zones
+                zone.classList.remove('correct', 'incorrect'); // Remove the style classes
             });
         }
 
@@ -174,36 +175,36 @@
         function checkAnswers() {
             const dropzones = document.querySelectorAll('.dropzone');
 
-            // Verificar os termos nas caixas (dropzones)
+            // Check the terms in the boxes (dropzones)
             dropzones.forEach((zone, index) => {
                 const termsInZone = Array.from(zone.getElementsByClassName('term'));
-                const expectedTerms = validTerms[index]; // Usa apenas termos válidos
+                const expectedTerms = validTerms[index]; // Use only valid terms
 
                 termsInZone.forEach(termElement => {
-                    const term = termElement.innerText.trim(); // Remover espaços desnecessários ao redor do termo
+                    const term = termElement.innerText.trim(); // Remove unnecessary spaces around the term
                     let isCorrect = false;
 
-                    // Verifica se o termo completo é igual ou se é parte dos termos separados por |
+                    // Check if the complete term is equal or if it's part of terms separated by |
                     expectedTerms.forEach(expectedTerm => {
-                        // Suprimir espaços ao redor de cada termo, mas manter os espaços internos
-                        const possibleAnswers = expectedTerm.split('|').map(t => t.trim()); // Usa trim() para cada termo
+                        // Remove spaces around each term, but keep internal spaces
+                        const possibleAnswers = expectedTerm.split('|').map(t => t.trim()); // Use trim() for each term
                         if (possibleAnswers.includes(term)) {
                             isCorrect = true;
                         }
                     });
 
-                    // Remove ícones anteriores
+                    // Remove previous icons
                     termElement.querySelectorAll('.question-plus-one, .question-minus-one, .correct-answer-hint').forEach(icon => icon.remove());
 
                     if (isCorrect) {
                         termElement.classList.add('correct');
                         termElement.classList.remove('incorrect');
-                        // Adiciona ícone de +1
+                        // Add +1 icon
                         termElement.insertAdjacentHTML('beforeend', '<div class="question-plus-one"></div>');
                     } else {
                         termElement.classList.add('incorrect');
                         termElement.classList.remove('correct');
-                        // Adiciona ícone de -1
+                        // Add -1 icon
                         termElement.insertAdjacentHTML('beforeend', '<div class="question-minus-one"></div>');
                         // Find and show correct category
                         const correctCategory = findCorrectCategory(term, validTerms, validHeaders);
@@ -214,15 +215,15 @@
                 });
             });
 
-            // Verificar os termos que não foram associados a nenhuma caixa (esquecidos)
+            // Check terms that were not associated with any box (forgotten)
             const remainingTerms = document.querySelectorAll('#terms-container .term');
             remainingTerms.forEach(termElement => {
-                // Marcar como incorretos (foram esquecidos)
+                // Mark as incorrect (were forgotten)
                 termElement.classList.add('incorrect');
                 termElement.classList.remove('correct');
-                // Remove ícones anteriores
+                // Remove previous icons
                 termElement.querySelectorAll('.question-plus-one, .question-minus-one, .correct-answer-hint').forEach(icon => icon.remove());
-                // Adicionar ícone de -1
+                // Add -1 icon
                 termElement.insertAdjacentHTML('beforeend', '<div class="question-minus-one"></div>');
                 // Find and show correct category for forgotten terms
                 const term = termElement.innerText.trim();
@@ -239,10 +240,6 @@
     }
 
     function findCorrectCategory(term, validTerms, validHeaders) {
-        // Debug: log what we're searching for
-        console.log('Looking for term:', term);
-        console.log('Valid terms structure:', validTerms);
-        console.log('Valid headers:', validHeaders);
         
         for (let i = 0; i < validTerms.length; i++) {
             const categoryTerms = validTerms[i];
@@ -251,29 +248,26 @@
                 const currentTerm = categoryTerms[j];
                 // Handle multiple answers separated by |
                 const possibleAnswers = currentTerm.split('|').map(t => t.trim());
-                console.log(`Checking category ${validHeaders[i]}, term ${currentTerm}, possible answers:`, possibleAnswers);
                 
                 if (possibleAnswers.includes(term.trim())) {
-                    console.log('Found match in category:', validHeaders[i]);
                     return validHeaders[i];
                 }
             }
         }
-        console.log('No match found for term:', term);
         return null;
     }
 
     function generateTable(layout, headers) {
         let tableHTML = '';
         if (layout === 'V') {
-            // Layout vertical
+            // Vertical layout
             tableHTML = `<table><thead><tr><th></th><th>Terms</th></tr></thead><tbody>`;
             headers.forEach((header, index) => {
                 tableHTML += `<tr><th>${header}</th><td id="col${index + 1}-vert" class="dropzone"></td></tr>`;
             });
             tableHTML += `</tbody></table>`;
         } else {
-            // Layout horizontal
+            // Horizontal layout
             tableHTML = `<table><thead><tr>`;
             headers.forEach((header, index) => {
                 tableHTML += `<th id="header${index + 1}">${header}</th>`;

--- a/front.html
+++ b/front.html
@@ -64,8 +64,7 @@
         const termsContainer = document.getElementById("terms-container");
 
         function initializeGame(layoutParam, validTermsParam, allTermsParam, termsContainerParam) {
-            // Always ensure clean state - critical for repeated reviews
-            resetToCleanState(termsContainerParam);
+            clearTable();
             
             // Check if we should show solution (only exists on back side)
             if (window.ankiShowSolution === true) {
@@ -93,9 +92,9 @@
                 return;
             }
             
-            // Enhanced shuffle logic with better randomization
-            const shuffledTerms = enhancedShuffle(allTermsParam);
-            termsContainerParam.innerHTML = shuffledTerms.map(term => `<div class="term draggable" draggable="true">${term}</div>`).join('');
+            // Original game logic
+            allTermsParam = allTermsParam.sort(() => Math.random() - 0.5);
+            termsContainerParam.innerHTML = allTermsParam.map(term => `<div class="term draggable" draggable="true">${term}</div>`).join('');
 
             const draggableItems = document.querySelectorAll('.draggable');
             draggableItems.forEach(item => {
@@ -118,42 +117,6 @@
                 zone.innerHTML = ''; // Limpa todos os termos dentro das zonas de drop
                 zone.classList.remove('correct', 'incorrect'); // Remove as classes de estilo
             });
-        }
-
-        // NEW FUNCTION - addresses the root cause of persistent DOM state
-        function resetToCleanState(termsContainer) {
-            // Clear dropzones (handles case where terms persist from previous review)
-            const dropzones = document.querySelectorAll('.dropzone');
-            dropzones.forEach(zone => {
-                zone.innerHTML = '';
-                zone.classList.remove('correct', 'incorrect');
-            });
-            
-            // Clear terms container
-            termsContainer.innerHTML = '';
-        }
-
-        // NEW FUNCTION - enhanced randomization with better fallback
-        function enhancedShuffle(array) {
-            const arr = [...array];
-            for (let i = arr.length - 1; i > 0; i--) {
-                let j;
-                // More robust crypto check
-                try {
-                    if (window.crypto && window.crypto.getRandomValues && typeof window.crypto.getRandomValues === 'function') {
-                        const randomValues = new Uint32Array(1);
-                        window.crypto.getRandomValues(randomValues);
-                        j = Math.floor((randomValues[0] / 4294967296) * (i + 1));
-                    } else {
-                        throw new Error('Crypto not available');
-                    }
-                } catch (e) {
-                    // Fallback to Math.random
-                    j = Math.floor(Math.random() * (i + 1));
-                }
-                [arr[i], arr[j]] = [arr[j], arr[i]];
-            }
-            return arr;
         }
 
         function dragStart(e) {

--- a/front.html
+++ b/front.html
@@ -64,7 +64,8 @@
         const termsContainer = document.getElementById("terms-container");
 
         function initializeGame(layoutParam, validTermsParam, allTermsParam, termsContainerParam) {
-            clearTable();
+            // Always ensure clean state - critical for repeated reviews
+            resetToCleanState(termsContainerParam);
             
             // Check if we should show solution (only exists on back side)
             if (window.ankiShowSolution === true) {
@@ -92,9 +93,9 @@
                 return;
             }
             
-            // Original game logic
-            allTermsParam = allTermsParam.sort(() => Math.random() - 0.5);
-            termsContainerParam.innerHTML = allTermsParam.map(term => `<div class="term draggable" draggable="true">${term}</div>`).join('');
+            // Enhanced shuffle logic with better randomization
+            const shuffledTerms = enhancedShuffle(allTermsParam);
+            termsContainerParam.innerHTML = shuffledTerms.map(term => `<div class="term draggable" draggable="true">${term}</div>`).join('');
 
             const draggableItems = document.querySelectorAll('.draggable');
             draggableItems.forEach(item => {
@@ -117,6 +118,42 @@
                 zone.innerHTML = ''; // Limpa todos os termos dentro das zonas de drop
                 zone.classList.remove('correct', 'incorrect'); // Remove as classes de estilo
             });
+        }
+
+        // NEW FUNCTION - addresses the root cause of persistent DOM state
+        function resetToCleanState(termsContainer) {
+            // Clear dropzones (handles case where terms persist from previous review)
+            const dropzones = document.querySelectorAll('.dropzone');
+            dropzones.forEach(zone => {
+                zone.innerHTML = '';
+                zone.classList.remove('correct', 'incorrect');
+            });
+            
+            // Clear terms container
+            termsContainer.innerHTML = '';
+        }
+
+        // NEW FUNCTION - enhanced randomization with better fallback
+        function enhancedShuffle(array) {
+            const arr = [...array];
+            for (let i = arr.length - 1; i > 0; i--) {
+                let j;
+                // More robust crypto check
+                try {
+                    if (window.crypto && window.crypto.getRandomValues && typeof window.crypto.getRandomValues === 'function') {
+                        const randomValues = new Uint32Array(1);
+                        window.crypto.getRandomValues(randomValues);
+                        j = Math.floor((randomValues[0] / 4294967296) * (i + 1));
+                    } else {
+                        throw new Error('Crypto not available');
+                    }
+                } catch (e) {
+                    // Fallback to Math.random
+                    j = Math.floor(Math.random() * (i + 1));
+                }
+                [arr[i], arr[j]] = [arr[j], arr[i]];
+            }
+            return arr;
         }
 
         function dragStart(e) {

--- a/front.html
+++ b/front.html
@@ -192,6 +192,11 @@ if (typeof(window.Persistence) === 'undefined') {
                 zone.addEventListener('drop', drop);
             });
 
+            // Add drag-drop capability to terms container
+            const termsContainer = document.getElementById("terms-container");
+            termsContainer.addEventListener('dragover', dragOver);
+            termsContainer.addEventListener('drop', drop);
+
             document.getElementById("resetButton").style.display = 'none';
         }
         
@@ -229,11 +234,19 @@ if (typeof(window.Persistence) === 'undefined') {
         function dragEnd(e) {
             setTimeout(() => {
                 e.target.classList.remove('hide');
+                // Remove visual feedback from terms container
+                const termsContainer = document.getElementById("terms-container");
+                termsContainer.classList.remove('dragover');
             }, 0);
         }
 
         function dragOver(e) {
             e.preventDefault();
+            // Add visual feedback for terms container
+            if (e.target.id === 'terms-container' || e.target.closest('#terms-container')) {
+                const termsContainer = document.getElementById("terms-container");
+                termsContainer.classList.add('dragover');
+            }
         }
 
         function drop(e) {
@@ -251,6 +264,18 @@ if (typeof(window.Persistence) === 'undefined') {
                 const draggedItem = document.querySelector(`.draggable.hide`);
                 if (draggedItem) draggedItem.remove();
 
+                reattachDragEvents();
+            } else if (targetZone.id === 'terms-container' || targetZone.closest('#terms-container')) {
+                // Handle drop back to terms container
+                const termsContainer = document.getElementById("terms-container");
+                termsContainer.innerHTML += `<div class="term draggable" draggable="true">${term}</div>`;
+                
+                const draggedItem = document.querySelector(`.draggable.hide`);
+                if (draggedItem) draggedItem.remove();
+                
+                // Remove visual feedback
+                termsContainer.classList.remove('dragover');
+                
                 reattachDragEvents();
             } else {
                 const draggedItem = document.querySelector(`.draggable.hide`);

--- a/style.css
+++ b/style.css
@@ -1,4 +1,3 @@
-<style>
     body {
         font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
         background-color: #f0f0f0;
@@ -136,4 +135,10 @@
         opacity: 1;
         transition: opacity 150ms linear, transform 150ms linear;
     }
-</style>
+
+    /* Visual feedback for terms container when dragging */
+    #terms-container.dragover {
+        background-color: #e8f5e8;
+        border: 2px dashed #58cc02;
+        border-radius: 8px;
+    }


### PR DESCRIPTION
#7 Enable dragging terms back to container" 

Summary
 Users can now drag terms back from table cells to the original container to "unassign" them.

 Changes
  - Added drag-drop event listeners to terms container
  - Extended drop function to handle returns to container
  - Added visual feedback (green border) when dragging over container

 Testing
  - ✅ Terms can be dragged back to container (new feature)
  - ✅ All existing drag-drop functionality preserved
  - ✅ Visual feedback works correctly